### PR TITLE
feat: add message_templates table (Issue #11 Stage 2)

### DIFF
--- a/supabase/migrations/20260427000000_add_message_templates.sql
+++ b/supabase/migrations/20260427000000_add_message_templates.sql
@@ -1,0 +1,49 @@
+-- =============================================================================
+-- message_templates テーブル (Issue #11 Stage 2)
+-- =============================================================================
+-- シフト連絡で使う定型文テンプレートを格納する。
+-- type: 'attend' (出勤) | 'off' (休み) の2種類、各1行のみ許容。
+-- プレースホルダー記法と変数仕様は docs/template-spec.md を参照。
+-- =============================================================================
+
+create table public.message_templates (
+  id         uuid        primary key default gen_random_uuid(),
+  type       text        not null unique check (type in ('attend', 'off')),
+  body       text        not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- =============================================================================
+-- Row Level Security
+-- =============================================================================
+-- 読み取りは認証済みユーザー全員、書き込みはマネージャーのみ。
+-- is_manager() は initial_schema で定義済み。
+-- =============================================================================
+
+alter table public.message_templates enable row level security;
+
+create policy "authenticated_select_message_templates"
+  on public.message_templates for select to authenticated
+  using (true);
+
+create policy "managers_insert_message_templates"
+  on public.message_templates for insert to authenticated
+  with check (public.is_manager());
+
+create policy "managers_update_message_templates"
+  on public.message_templates for update to authenticated
+  using (public.is_manager())
+  with check (public.is_manager());
+
+create policy "managers_delete_message_templates"
+  on public.message_templates for delete to authenticated
+  using (public.is_manager());
+
+-- =============================================================================
+-- 初期シードデータ (docs/template-spec.md §8 より)
+-- =============================================================================
+
+insert into public.message_templates (type, body) values
+  ('attend', '明日 {date} は {time} からです'),
+  ('off',    '明日 {date} はお休みです');


### PR DESCRIPTION
Refs #11

## Summary
Issue #11 Stage 2: adds the DB schema for message templates.

## Changes
- Create the message_templates table (type/body/timestamps)
- CHECK constraint on type ('attend' | 'off') and a unique constraint
- Enable RLS; writes restricted via is_manager()
- Seed the sample templates from spec §8

## Spec compliance
- Matches the sample templates in docs/template-spec.md §8
- updated_at is maintained by the app (same as the existing employees/shifts tables)

## Next step
Stage 3: template settings page UI