### PR TITLE
feat: add template preview feature (Issue #11 Stage 5)

### DIFF
--- a/app/(dashboard)/settings/templates/page.tsx
+++ b/app/(dashboard)/settings/templates/page.tsx
@@ -1,5 +1,6 @@
 import { requireManager } from '@/lib/auth/manager'
 import { createClient } from '@/lib/supabase/server'
+import { TemplateForm } from '@/components/features/template-form'
 import { updateTemplate } from './actions'
 
 const TEMPLATE_LABELS: Record<string, string> = {
@@ -60,29 +61,12 @@ export default async function TemplatesPage({
         {(['attend', 'off'] as const).map((type) => (
           <div key={type} className="space-y-3 rounded border border-zinc-200 p-4">
             <h2 className="font-semibold">{TEMPLATE_LABELS[type]}</h2>
-            <form action={updateTemplate} className="space-y-3">
-              <input type="hidden" name="type" value={type} />
-              <textarea
-                name="body"
-                defaultValue={templateMap[type] ?? ''}
-                rows={3}
-                className="w-full rounded border border-zinc-400 px-3 py-2 text-sm focus:border-zinc-700 focus:outline-none"
-              />
-              <p className="text-xs text-zinc-500">
-                利用可能な変数:{' '}
-                {TEMPLATE_HINTS[type].map((v) => (
-                  <code key={v} className="mr-2 rounded bg-zinc-100 px-1 py-0.5 font-mono">
-                    {v}
-                  </code>
-                ))}
-              </p>
-              <button
-                type="submit"
-                className="rounded bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800"
-              >
-                保存する
-              </button>
-            </form>
+            <TemplateForm
+              type={type}
+              defaultBody={templateMap[type] ?? ''}
+              hints={TEMPLATE_HINTS[type]}
+              action={updateTemplate}
+            />
           </div>
         ))}
       </div>

--- a/components/features/template-form.tsx
+++ b/components/features/template-form.tsx
@@ -1,44 +1,11 @@
 'use client'
 
 import { useState } from 'react'
-import type { TemplateVars } from '@/lib/utils/render-template'
+import { parseSegments, type TemplateVars } from '@/lib/utils/render-template'
 
 const PREVIEW_VARS: TemplateVars = {
   date: '4月26日(日)',
   time: '9:00',
-}
-
-type Segment = { kind: 'text'; value: string } | { kind: 'unknown'; variable: string }
-
-function parseSegments(template: string, vars: TemplateVars): Segment[] {
-  const segments: Segment[] = []
-  const regex = /\\([\\{}])|(\{[a-z][a-z0-9_]*\})/g
-  let lastIndex = 0
-  let match: RegExpExecArray | null
-
-  while ((match = regex.exec(template)) !== null) {
-    if (match.index > lastIndex) {
-      segments.push({ kind: 'text', value: template.slice(lastIndex, match.index) })
-    }
-    if (match[1] !== undefined) {
-      segments.push({ kind: 'text', value: match[1] })
-    } else {
-      const key = match[2].slice(1, -1)
-      const value = vars[key as keyof TemplateVars]
-      if (value != null) {
-        segments.push({ kind: 'text', value })
-      } else {
-        segments.push({ kind: 'unknown', variable: key })
-      }
-    }
-    lastIndex = regex.lastIndex
-  }
-
-  if (lastIndex < template.length) {
-    segments.push({ kind: 'text', value: template.slice(lastIndex) })
-  }
-
-  return segments
 }
 
 interface TemplateFormProps {
@@ -50,7 +17,7 @@ interface TemplateFormProps {
 
 export function TemplateForm({ type, defaultBody, hints, action }: TemplateFormProps) {
   const [body, setBody] = useState(defaultBody)
-  const segments = parseSegments(body, PREVIEW_VARS)
+  const segments = parseSegments(body)
 
   return (
     <form action={action} className="space-y-3">
@@ -73,16 +40,21 @@ export function TemplateForm({ type, defaultBody, hints, action }: TemplateFormP
 
       <div className="space-y-1">
         <p className="text-xs text-zinc-500">プレビュー（サンプル値で表示）</p>
-        <div className="min-h-8 rounded border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm whitespace-pre-wrap">
+        <div
+          aria-label="プレビュー"
+          className="min-h-8 rounded border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm whitespace-pre-wrap"
+        >
           {segments.length === 0 ? (
             <span className="text-zinc-400">テンプレートを入力してください</span>
           ) : (
             segments.map((seg, i) =>
               seg.kind === 'text' ? (
                 <span key={i}>{seg.value}</span>
+              ) : PREVIEW_VARS[seg.name as keyof TemplateVars] != null ? (
+                <span key={i}>{PREVIEW_VARS[seg.name as keyof TemplateVars]}</span>
               ) : (
                 <span key={i} className="rounded bg-amber-100 px-0.5 text-amber-700">
-                  {`{${seg.variable}}`}
+                  {`{${seg.name}}`}
                 </span>
               )
             )

--- a/components/features/template-form.tsx
+++ b/components/features/template-form.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { useState } from 'react'
+import type { TemplateVars } from '@/lib/utils/render-template'
+
+const PREVIEW_VARS: TemplateVars = {
+  date: '4月26日(日)',
+  time: '9:00',
+}
+
+type Segment = { kind: 'text'; value: string } | { kind: 'unknown'; variable: string }
+
+function parseSegments(template: string, vars: TemplateVars): Segment[] {
+  const segments: Segment[] = []
+  const regex = /\\([\\{}])|(\{[a-z][a-z0-9_]*\})/g
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  while ((match = regex.exec(template)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ kind: 'text', value: template.slice(lastIndex, match.index) })
+    }
+    if (match[1] !== undefined) {
+      segments.push({ kind: 'text', value: match[1] })
+    } else {
+      const key = match[2].slice(1, -1)
+      const value = vars[key as keyof TemplateVars]
+      if (value != null) {
+        segments.push({ kind: 'text', value })
+      } else {
+        segments.push({ kind: 'unknown', variable: key })
+      }
+    }
+    lastIndex = regex.lastIndex
+  }
+
+  if (lastIndex < template.length) {
+    segments.push({ kind: 'text', value: template.slice(lastIndex) })
+  }
+
+  return segments
+}
+
+interface TemplateFormProps {
+  type: 'attend' | 'off'
+  defaultBody: string
+  hints: string[]
+  action: (formData: FormData) => Promise<void>
+}
+
+export function TemplateForm({ type, defaultBody, hints, action }: TemplateFormProps) {
+  const [body, setBody] = useState(defaultBody)
+  const segments = parseSegments(body, PREVIEW_VARS)
+
+  return (
+    <form action={action} className="space-y-3">
+      <input type="hidden" name="type" value={type} />
+      <textarea
+        name="body"
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        rows={3}
+        className="w-full rounded border border-zinc-400 px-3 py-2 text-sm focus:border-zinc-700 focus:outline-none"
+      />
+      <p className="text-xs text-zinc-500">
+        利用可能な変数:{' '}
+        {hints.map((v) => (
+          <code key={v} className="mr-2 rounded bg-zinc-100 px-1 py-0.5 font-mono">
+            {v}
+          </code>
+        ))}
+      </p>
+
+      <div className="space-y-1">
+        <p className="text-xs text-zinc-500">プレビュー（サンプル値で表示）</p>
+        <div className="min-h-8 rounded border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm whitespace-pre-wrap">
+          {segments.length === 0 ? (
+            <span className="text-zinc-400">テンプレートを入力してください</span>
+          ) : (
+            segments.map((seg, i) =>
+              seg.kind === 'text' ? (
+                <span key={i}>{seg.value}</span>
+              ) : (
+                <span key={i} className="rounded bg-amber-100 px-0.5 text-amber-700">
+                  {`{${seg.variable}}`}
+                </span>
+              )
+            )
+          )}
+        </div>
+      </div>
+
+      <button
+        type="submit"
+        className="rounded bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800"
+      >
+        保存する
+      </button>
+    </form>
+  )
+}

--- a/lib/utils/render-template.ts
+++ b/lib/utils/render-template.ts
@@ -3,6 +3,33 @@ export type TemplateVars = {
   time?: string
 }
 
+export type Segment = { kind: 'text'; value: string } | { kind: 'placeholder'; name: string }
+
+export function parseSegments(template: string): Segment[] {
+  const segments: Segment[] = []
+  const regex = /\\([\\{}])|(\{[a-z][a-z0-9_]*\})/g
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  while ((match = regex.exec(template)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ kind: 'text', value: template.slice(lastIndex, match.index) })
+    }
+    if (match[1] !== undefined) {
+      segments.push({ kind: 'text', value: match[1] })
+    } else {
+      segments.push({ kind: 'placeholder', name: match[2].slice(1, -1) })
+    }
+    lastIndex = regex.lastIndex
+  }
+
+  if (lastIndex < template.length) {
+    segments.push({ kind: 'text', value: template.slice(lastIndex) })
+  }
+
+  return segments
+}
+
 /**
  * テンプレート文字列を変数で置換する。
  * - 未定義変数（vars に無い、または値が null/undefined）は原文のまま残す。


### PR DESCRIPTION
Refs #11

## Summary
Issue #11 Stage 5: adds a real-time preview while editing templates.

## Changes
- `components/features/template-form.tsx` — Client Component (form with preview)
- `app/(dashboard)/settings/templates/page.tsx` — swapped in TemplateForm

## Behavior
- The preview updates in real time as the textarea is edited
- Shows the substitution result with sample values (date: `4月26日(日)` / time: `9:00`)
- Undefined variables (e.g. `{foo}`) are highlighted in amber

## Dependencies
- Builds on Stage 3 (template settings page)
- Incorporates the parseSegments logic from Stage 4 (renderTemplate)