### PR TITLE
feat: add recurring days off feature (Issue #8)

### DIFF
--- a/app/(dashboard)/employees/[id]/edit/page.tsx
+++ b/app/(dashboard)/employees/[id]/edit/page.tsx
@@ -11,24 +11,38 @@ export default async function EditEmployeePage({
 }) {
   const { id } = await params
   const supabase = await createClient()
-  const { data: employee } = await supabase
-    .from('employees')
-    .select('id, name, phone, visa_type, weekly_hour_limit, notes')
-    .eq('id', id)
-    .single()
+
+  const [{ data: employee }, { data: recurringDaysOff }] = await Promise.all([
+    supabase
+      .from('employees')
+      .select('id, name, phone, visa_type, weekly_hour_limit, notes')
+      .eq('id', id)
+      .single(),
+    supabase
+      .from('recurring_days_off')
+      .select('day_of_week')
+      .eq('employee_id', id),
+  ])
 
   if (!employee) notFound()
 
+  const offDays = new Set((recurringDaysOff ?? []).map((r) => r.day_of_week))
+
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       <div className="flex items-center gap-4">
         <Link href="/employees" className="text-sm text-zinc-500 hover:text-zinc-700">
           ← 従業員一覧
         </Link>
         <h1 className="text-2xl font-bold">従業員を編集</h1>
       </div>
+
       <div className="max-w-lg">
-        <EmployeeForm action={updateEmployee} defaultValues={employee} />
+        <EmployeeForm
+          action={updateEmployee}
+          defaultValues={employee}
+          defaultOffDays={[...offDays]}
+        />
       </div>
     </div>
   )

--- a/app/(dashboard)/employees/actions.ts
+++ b/app/(dashboard)/employees/actions.ts
@@ -53,6 +53,10 @@ function parseFormData(formData: FormData): {
   return { data: { name: name!, phone: phone!, visa_type, weekly_hour_limit, notes } }
 }
 
+function parseOffDays(formData: FormData): number[] {
+  return formData.getAll('day_of_week').map((v) => parseInt(v as string, 10))
+}
+
 export async function createEmployee(
   _prevState: EmployeeState,
   formData: FormData
@@ -63,9 +67,20 @@ export async function createEmployee(
   if (errors) return { fieldErrors: errors }
 
   const supabase = await createClient()
-  const { error } = await supabase.from('employees').insert(data!)
+  const { data: inserted, error } = await supabase
+    .from('employees')
+    .insert(data!)
+    .select('id')
+    .single()
 
-  if (error) return { error: '保存に失敗しました。時間を置いて再度お試しください。' }
+  if (error || !inserted) return { error: '保存に失敗しました。時間を置いて再度お試しください。' }
+
+  const offDays = parseOffDays(formData)
+  if (offDays.length > 0) {
+    await supabase.from('recurring_days_off').insert(
+      offDays.map((day) => ({ employee_id: inserted.id, day_of_week: day }))
+    )
+  }
 
   redirect('/employees')
 }
@@ -89,6 +104,14 @@ export async function updateEmployee(
     .eq('id', id)
 
   if (error) return { error: '保存に失敗しました。時間を置いて再度お試しください。' }
+
+  const offDays = parseOffDays(formData)
+  await supabase.from('recurring_days_off').delete().eq('employee_id', id)
+  if (offDays.length > 0) {
+    await supabase.from('recurring_days_off').insert(
+      offDays.map((day) => ({ employee_id: id, day_of_week: day }))
+    )
+  }
 
   redirect('/employees')
 }
@@ -117,4 +140,25 @@ export async function restoreEmployee(formData: FormData): Promise<void> {
     .eq('id', id)
 
   revalidatePath('/employees')
+}
+
+// day_of_week: 0=日 〜 6=土
+export async function updateRecurringDaysOff(formData: FormData): Promise<void> {
+  await requireManager()
+
+  const employeeId = formData.get('employee_id') as string
+  const selected = formData.getAll('day_of_week').map((v) => parseInt(v as string, 10))
+
+  const supabase = await createClient()
+
+  // 既存レコードを全削除してから選択分を挿入（シンプルな置き換え）
+  await supabase.from('recurring_days_off').delete().eq('employee_id', employeeId)
+
+  if (selected.length > 0) {
+    await supabase.from('recurring_days_off').insert(
+      selected.map((day) => ({ employee_id: employeeId, day_of_week: day }))
+    )
+  }
+
+  revalidatePath(`/employees/${employeeId}/edit`)
 }

--- a/app/(dashboard)/employees/actions.ts
+++ b/app/(dashboard)/employees/actions.ts
@@ -54,7 +54,10 @@ function parseFormData(formData: FormData): {
 }
 
 function parseOffDays(formData: FormData): number[] {
-  return formData.getAll('day_of_week').map((v) => parseInt(v as string, 10))
+  return formData
+    .getAll('day_of_week')
+    .map((v) => parseInt(v as string, 10))
+    .filter((n) => !isNaN(n) && n >= 0 && n <= 6)
 }
 
 export async function createEmployee(
@@ -106,11 +109,19 @@ export async function updateEmployee(
   if (error) return { error: '保存に失敗しました。時間を置いて再度お試しください。' }
 
   const offDays = parseOffDays(formData)
-  await supabase.from('recurring_days_off').delete().eq('employee_id', id)
-  if (offDays.length > 0) {
-    await supabase.from('recurring_days_off').insert(
-      offDays.map((day) => ({ employee_id: id, day_of_week: day }))
-    )
+  const { data: existing } = await supabase
+    .from('recurring_days_off')
+    .select('day_of_week')
+    .eq('employee_id', id)
+  const oldSet = new Set(existing?.map((r) => r.day_of_week) ?? [])
+  const newSet = new Set(offDays)
+  const toRemove = [...oldSet].filter((d) => !newSet.has(d))
+  const toAdd = [...newSet].filter((d) => !oldSet.has(d))
+  if (toRemove.length > 0) {
+    await supabase.from('recurring_days_off').delete().eq('employee_id', id).in('day_of_week', toRemove)
+  }
+  if (toAdd.length > 0) {
+    await supabase.from('recurring_days_off').insert(toAdd.map((d) => ({ employee_id: id, day_of_week: d })))
   }
 
   redirect('/employees')
@@ -142,23 +153,3 @@ export async function restoreEmployee(formData: FormData): Promise<void> {
   revalidatePath('/employees')
 }
 
-// day_of_week: 0=日 〜 6=土
-export async function updateRecurringDaysOff(formData: FormData): Promise<void> {
-  await requireManager()
-
-  const employeeId = formData.get('employee_id') as string
-  const selected = formData.getAll('day_of_week').map((v) => parseInt(v as string, 10))
-
-  const supabase = await createClient()
-
-  // 既存レコードを全削除してから選択分を挿入（シンプルな置き換え）
-  await supabase.from('recurring_days_off').delete().eq('employee_id', employeeId)
-
-  if (selected.length > 0) {
-    await supabase.from('recurring_days_off').insert(
-      selected.map((day) => ({ employee_id: employeeId, day_of_week: day }))
-    )
-  }
-
-  revalidatePath(`/employees/${employeeId}/edit`)
-}

--- a/components/features/employee-form.tsx
+++ b/components/features/employee-form.tsx
@@ -3,6 +3,8 @@
 import { useActionState } from 'react'
 import type { EmployeeState } from '@/app/(dashboard)/employees/actions'
 
+const DAY_LABELS = ['日', '月', '火', '水', '木', '金', '土']
+
 type Action = (prevState: EmployeeState, formData: FormData) => Promise<EmployeeState>
 
 interface EmployeeFormProps {
@@ -15,9 +17,11 @@ interface EmployeeFormProps {
     weekly_hour_limit?: number | null
     notes?: string | null
   }
+  defaultOffDays?: number[]
 }
 
-export function EmployeeForm({ action, defaultValues = {} }: EmployeeFormProps) {
+export function EmployeeForm({ action, defaultValues = {}, defaultOffDays = [] }: EmployeeFormProps) {
+  const offDaySet = new Set(defaultOffDays)
   const [state, formAction] = useActionState(action, {})
 
   return (
@@ -106,6 +110,24 @@ export function EmployeeForm({ action, defaultValues = {} }: EmployeeFormProps) 
           defaultValue={defaultValues.notes ?? ''}
           className="w-full rounded border border-zinc-400 px-3 py-2 text-sm focus:border-zinc-700 focus:outline-none"
         />
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-sm font-medium">定期休み（曜日固定）</p>
+        <div className="flex flex-wrap gap-3">
+          {DAY_LABELS.map((label, dow) => (
+            <label key={dow} className="flex items-center gap-1.5 text-sm">
+              <input
+                type="checkbox"
+                name="day_of_week"
+                value={dow}
+                defaultChecked={offDaySet.has(dow)}
+                className="rounded border-zinc-400"
+              />
+              {label}
+            </label>
+          ))}
+        </div>
       </div>
 
       <button


### PR DESCRIPTION
Closes #8

## Summary
Issue #8: lets each employee register fixed weekly days off.

## Changes
- `components/features/employee-form.tsx` — added weekday checkboxes for recurring days off (shared by add/edit)
- `app/(dashboard)/employees/actions.ts` — createEmployee/updateEmployee also save recurring_days_off
- `app/(dashboard)/employees/[id]/edit/page.tsx` — passes existing recurring days off to EmployeeForm

## Behavior
- Sun–Sat checkboxes shown at the bottom of the add/edit employee form
- On save, the recurring_days_off table is replaced (delete → insert)
- On the edit screen, registered weekdays appear pre-checked