### PR TITLE
feat: implement API endpoints for iOS Shortcut (Issue #13)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 # パスワードリセット等のメールリンクで使う絶対URL。
 # 開発時: http://localhost:3000、本番: https://<project>.vercel.app
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
+
+# iOSショートカット認証用トークン（任意の長いランダム文字列）
+SHORTCUT_API_TOKEN=your-secret-token

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -12,6 +12,13 @@ export default async function DashboardPage() {
       </div>
 
       <div className="grid gap-3 sm:grid-cols-2">
+        <Link
+          href="/shifts"
+          className="rounded border border-zinc-900 bg-zinc-900 p-4 text-white hover:bg-zinc-800"
+        >
+          <div className="font-semibold">シフト入力</div>
+          <div className="mt-1 text-sm text-zinc-400">翌日のシフトを入力・管理する</div>
+        </Link>
         <Link href="/employees" className="rounded border border-zinc-200 p-4 hover:bg-zinc-50">
           <div className="font-semibold">従業員管理</div>
           <div className="mt-1 text-sm text-zinc-500">従業員の追加・編集・アーカイブ</div>

--- a/app/(dashboard)/employees/[id]/edit/page.tsx
+++ b/app/(dashboard)/employees/[id]/edit/page.tsx
@@ -14,7 +14,7 @@ export default async function EditEmployeePage({ params }: { params: Promise<{ i
   const [{ data: employee }, { data: recurringDaysOff }] = await Promise.all([
     supabase
       .from('employees')
-      .select('id, name, phone, visa_type, weekly_hour_limit, notes')
+      .select('id, name, phone, visa_type, weekly_hour_limit, notes, is_manager')
       .eq('id', id)
       .single(),
     supabase.from('recurring_days_off').select('day_of_week').eq('employee_id', id),

--- a/app/(dashboard)/employees/actions.ts
+++ b/app/(dashboard)/employees/actions.ts
@@ -18,6 +18,7 @@ function parseFormData(formData: FormData): {
     visa_type: string | null
     weekly_hour_limit: number | null
     notes: string | null
+    is_manager: boolean
   }
   errors?: EmployeeState['fieldErrors']
 } {
@@ -26,6 +27,7 @@ function parseFormData(formData: FormData): {
   const visa_type = (formData.get('visa_type') as string | null)?.trim() || null
   const weeklyRaw = (formData.get('weekly_hour_limit') as string | null)?.trim()
   const notes = (formData.get('notes') as string | null)?.trim() || null
+  const is_manager = formData.get('is_manager') === 'true'
 
   const errors: EmployeeState['fieldErrors'] = {}
 
@@ -50,7 +52,7 @@ function parseFormData(formData: FormData): {
 
   if (Object.keys(errors).length > 0) return { errors }
 
-  return { data: { name: name!, phone: phone!, visa_type, weekly_hour_limit, notes } }
+  return { data: { name: name!, phone: phone!, visa_type, weekly_hour_limit, notes, is_manager } }
 }
 
 function parseOffDays(formData: FormData): number[] {

--- a/app/(dashboard)/shifts/actions.ts
+++ b/app/(dashboard)/shifts/actions.ts
@@ -1,0 +1,87 @@
+'use server'
+
+import { requireManager } from '@/lib/auth/manager'
+import { createClient } from '@/lib/supabase/server'
+import { revalidatePath } from 'next/cache'
+
+export async function upsertShift(
+  employeeId: string,
+  shiftDate: string,
+  payload: { startTime: string } | { isOff: true },
+): Promise<{ error?: string }> {
+  await requireManager()
+
+  const supabase = await createClient()
+  const row =
+    'isOff' in payload
+      ? {
+          employee_id: employeeId,
+          shift_date: shiftDate,
+          is_off: true,
+          start_time: null,
+          status: 'draft',
+          updated_at: new Date().toISOString(),
+        }
+      : {
+          employee_id: employeeId,
+          shift_date: shiftDate,
+          is_off: false,
+          start_time: payload.startTime,
+          status: 'draft',
+          updated_at: new Date().toISOString(),
+        }
+
+  const { error } = await supabase
+    .from('shifts')
+    .upsert(row, { onConflict: 'employee_id,shift_date' })
+
+  if (error) return { error: '保存に失敗しました' }
+
+  revalidatePath('/shifts')
+  return {}
+}
+
+export async function lockDate(shiftDate: string): Promise<{ error?: string }> {
+  await requireManager()
+
+  const supabase = await createClient()
+  const { error } = await supabase
+    .from('shift_locks')
+    .upsert({ shift_date: shiftDate }, { onConflict: 'shift_date' })
+
+  if (error) return { error: '確定に失敗しました' }
+
+  revalidatePath('/shifts')
+  return {}
+}
+
+export async function unlockDate(shiftDate: string): Promise<{ error?: string }> {
+  await requireManager()
+
+  const supabase = await createClient()
+  const { error } = await supabase.from('shift_locks').delete().eq('shift_date', shiftDate)
+
+  if (error) return { error: '確定解除に失敗しました' }
+
+  revalidatePath('/shifts')
+  return {}
+}
+
+export async function deleteShift(
+  employeeId: string,
+  shiftDate: string,
+): Promise<{ error?: string }> {
+  await requireManager()
+
+  const supabase = await createClient()
+  const { error } = await supabase
+    .from('shifts')
+    .delete()
+    .eq('employee_id', employeeId)
+    .eq('shift_date', shiftDate)
+
+  if (error) return { error: '削除に失敗しました' }
+
+  revalidatePath('/shifts')
+  return {}
+}

--- a/app/(dashboard)/shifts/page.tsx
+++ b/app/(dashboard)/shifts/page.tsx
@@ -1,0 +1,86 @@
+import { requireManager } from '@/lib/auth/manager'
+import { createClient } from '@/lib/supabase/server'
+import { ShiftGrid } from '@/components/features/shift-grid'
+
+function buildDateRange(startDate: string, days: number): string[] {
+  const dates: string[] = []
+  const base = new Date(startDate + 'T12:00:00Z')
+  for (let i = 0; i < days; i++) {
+    const d = new Date(base)
+    d.setUTCDate(d.getUTCDate() + i)
+    dates.push(d.toISOString().slice(0, 10))
+  }
+  return dates
+}
+
+const VANCOUVER_TZ = 'America/Vancouver'
+
+function todayInVancouver(): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: VANCOUVER_TZ,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date())
+}
+
+function defaultStartDate(): string {
+  const today = todayInVancouver()
+  const d = new Date(today + 'T12:00:00Z')
+  d.setUTCDate(d.getUTCDate() - 3)
+  return d.toISOString().slice(0, 10)
+}
+
+export default async function ShiftsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ date?: string }>
+}) {
+  await requireManager()
+
+  const { date } = await searchParams
+  const startDate = date ?? defaultStartDate()
+  const today = todayInVancouver()
+  const dates = buildDateRange(startDate, 7)
+  const endDate = dates[dates.length - 1]
+
+  const supabase = await createClient()
+
+  const [{ data: employees }, { data: requestedDaysOff }, { data: shifts }, { data: locks }] = await Promise.all([
+    supabase
+      .from('employees')
+      .select('id, name, notes, weekly_hour_limit, is_manager, recurring_days_off(day_of_week)')
+      .eq('is_active', true)
+      .order('name'),
+    supabase
+      .from('requested_days_off')
+      .select('employee_id, start_date, end_date')
+      .lte('start_date', endDate)
+      .gte('end_date', startDate),
+    supabase
+      .from('shifts')
+      .select('id, employee_id, shift_date, start_time, is_off, status')
+      .gte('shift_date', startDate)
+      .lte('shift_date', endDate),
+    supabase
+      .from('shift_locks')
+      .select('shift_date')
+      .gte('shift_date', startDate)
+      .lte('shift_date', endDate),
+  ])
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">シフト入力</h1>
+      <ShiftGrid
+        employees={employees ?? []}
+        dates={dates}
+        requestedDaysOff={requestedDaysOff ?? []}
+        initialShifts={shifts ?? []}
+        lockedDates={(locks ?? []).map((l) => l.shift_date)}
+        startDate={startDate}
+        today={today}
+      />
+    </div>
+  )
+}

--- a/app/api/shifts/messages/route.ts
+++ b/app/api/shifts/messages/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { verifyShortcutToken } from '@/lib/auth/shortcut'
+import { renderTemplate } from '@/lib/utils/render-template'
+
+const DAY_LABELS = ['日', '月', '火', '水', '木', '金', '土'] as const
+
+function formatMessageDate(date: string): string {
+  const d = new Date(date + 'T12:00:00Z')
+  const dow = DAY_LABELS[d.getUTCDay()]
+  return `${d.getUTCMonth() + 1}/${d.getUTCDate()} (${dow})`
+}
+
+function formatTime(t: string): string {
+  const [h, m] = t.split(':')
+  return `${parseInt(h, 10)}:${m}`
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  if (!verifyShortcutToken(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const date = request.nextUrl.searchParams.get('date')
+  if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return NextResponse.json({ error: 'date パラメータが必要です (YYYY-MM-DD)' }, { status: 400 })
+  }
+
+  const supabase = await createClient()
+
+  const [{ data: shifts, error: shiftsError }, { data: templates, error: templatesError }] =
+    await Promise.all([
+      supabase
+        .from('shifts')
+        .select('id, start_time, is_off, employees(name, phone)')
+        .eq('shift_date', date),
+      supabase.from('message_templates').select('type, body'),
+    ])
+
+  if (shiftsError || templatesError) {
+    return NextResponse.json({ error: 'データの取得に失敗しました' }, { status: 500 })
+  }
+
+  const attendTemplate = templates?.find((t) => t.type === 'attend')?.body ?? ''
+  const offTemplate = templates?.find((t) => t.type === 'off')?.body ?? ''
+  const dateLabel = formatMessageDate(date)
+
+  const messages = (shifts ?? [])
+    .map((shift) => {
+      const employee = Array.isArray(shift.employees) ? shift.employees[0] : shift.employees
+      if (!employee) return null
+
+      const body = shift.is_off
+        ? renderTemplate(offTemplate, { date: dateLabel })
+        : renderTemplate(attendTemplate, {
+            date: dateLabel,
+            time: formatTime(shift.start_time!),
+          })
+
+      return { phone: employee.phone, body, shift_id: shift.id }
+    })
+    .filter((m): m is NonNullable<typeof m> => m !== null)
+
+  return NextResponse.json({ date, messages })
+}

--- a/app/api/shifts/messages/sent/route.ts
+++ b/app/api/shifts/messages/sent/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { verifyShortcutToken } from '@/lib/auth/shortcut'
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  if (!verifyShortcutToken(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'リクエストボディが不正です' }, { status: 400 })
+  }
+
+  if (
+    typeof body !== 'object' ||
+    body === null ||
+    typeof (body as Record<string, unknown>).shift_id !== 'string' ||
+    typeof (body as Record<string, unknown>).message_body !== 'string'
+  ) {
+    return NextResponse.json(
+      { error: 'shift_id と message_body が必要です' },
+      { status: 400 },
+    )
+  }
+
+  const { shift_id, message_body } = body as { shift_id: string; message_body: string }
+
+  const supabase = await createClient()
+
+  const { error: updateError } = await supabase
+    .from('shifts')
+    .update({ status: 'sent', updated_at: new Date().toISOString() })
+    .eq('id', shift_id)
+
+  if (updateError) {
+    return NextResponse.json({ error: 'シフトステータスの更新に失敗しました' }, { status: 500 })
+  }
+
+  const { error: logError } = await supabase
+    .from('message_logs')
+    .insert({ shift_id, message_body })
+
+  if (logError) {
+    return NextResponse.json({ error: '送信ログの記録に失敗しました' }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/components/features/employee-form.tsx
+++ b/components/features/employee-form.tsx
@@ -17,6 +17,7 @@ interface EmployeeFormProps {
     visa_type?: string | null
     weekly_hour_limit?: number | null
     notes?: string | null
+    is_manager?: boolean
   }
   defaultOffDays?: number[]
 }
@@ -28,6 +29,7 @@ export function EmployeeForm({
 }: EmployeeFormProps) {
   const [state, formAction] = useActionState(action, {})
   const [offDays, setOffDays] = useState(new Set(defaultOffDays))
+  const [isManager, setIsManager] = useState(defaultValues.is_manager ?? false)
 
   const [fields, setFields] = useState({
     name: defaultValues.name ?? '',
@@ -45,6 +47,7 @@ export function EmployeeForm({
   return (
     <form action={formAction} className="space-y-5">
       {defaultValues.id && <input type="hidden" name="id" value={defaultValues.id} />}
+      <input type="hidden" name="is_manager" value={isManager ? 'true' : 'false'} />
 
       {state.error && (
         <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-800">
@@ -138,6 +141,18 @@ export function EmployeeForm({
           onChange={update('notes')}
           className="w-full rounded border border-zinc-400 px-3 py-2 text-sm focus:border-zinc-700 focus:outline-none"
         />
+      </div>
+
+      <div className="space-y-1">
+        <label className="flex items-center gap-2 text-sm font-medium">
+          <input
+            type="checkbox"
+            checked={isManager}
+            onChange={(e) => setIsManager(e.target.checked)}
+            className="rounded border-zinc-400"
+          />
+          マネージャー職（シフト自動入力: 9:00）
+        </label>
       </div>
 
       <div className="space-y-2">

--- a/components/features/shift-grid.tsx
+++ b/components/features/shift-grid.tsx
@@ -1,0 +1,420 @@
+'use client'
+
+import { useOptimistic, useTransition, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { upsertShift, deleteShift, lockDate, unlockDate } from '@/app/(dashboard)/shifts/actions'
+
+const PRESET_TIMES = ['9:00', '10:00', '11:00', '13:00'] as const
+const DAY_LABELS = ['日', '月', '火', '水', '木', '金', '土'] as const
+
+type Employee = {
+  id: string
+  name: string
+  notes: string | null
+  weekly_hour_limit: number | null
+  is_manager: boolean
+  recurring_days_off: { day_of_week: number }[]
+}
+
+type RequestedDayOff = {
+  employee_id: string
+  start_date: string
+  end_date: string
+}
+
+type Shift = {
+  id: string
+  employee_id: string
+  shift_date: string
+  start_time: string | null
+  is_off: boolean
+  status: string
+}
+
+type ShiftKey = string // `${employee_id}:${shift_date}`
+
+type ShiftMap = Record<ShiftKey, Shift>
+
+interface ShiftGridProps {
+  employees: Employee[]
+  dates: string[]
+  requestedDaysOff: RequestedDayOff[]
+  initialShifts: Shift[]
+  lockedDates: string[]
+  startDate: string
+  today: string
+}
+
+function toShiftMap(shifts: Shift[]): ShiftMap {
+  const map: ShiftMap = {}
+  for (const s of shifts) {
+    map[`${s.employee_id}:${s.shift_date}`] = s
+  }
+  return map
+}
+
+function formatTime(t: string): string {
+  const [h, m] = t.split(':')
+  return `${parseInt(h, 10)}:${m}`
+}
+
+function toDbTime(t: string): string {
+  const [h, m] = t.split(':')
+  return `${h.padStart(2, '0')}:${m.padStart(2, '0')}:00`
+}
+
+function formatDateHeader(date: string): { label: string; dow: number } {
+  const d = new Date(date + 'T12:00:00Z')
+  const dow = d.getUTCDay()
+  const label = `${d.getUTCMonth() + 1}/${d.getUTCDate()}(${DAY_LABELS[dow]})`
+  return { label, dow }
+}
+
+export function ShiftGrid({
+  employees,
+  dates,
+  requestedDaysOff,
+  initialShifts,
+  lockedDates,
+  startDate,
+  today,
+}: ShiftGridProps) {
+  const lockedSet = new Set(lockedDates)
+  const tomorrow = (() => {
+    const d = new Date(today + 'T12:00:00Z')
+    d.setUTCDate(d.getUTCDate() + 1)
+    return d.toISOString().slice(0, 10)
+  })()
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [activeCell, setActiveCell] = useState<string | null>(null)
+
+  const [optimisticMap, applyOptimistic] = useOptimistic(
+    toShiftMap(initialShifts),
+    (current: ShiftMap, action: { key: string; shift: Shift | null }) => {
+      const next = { ...current }
+      if (action.shift === null) {
+        delete next[action.key]
+      } else {
+        next[action.key] = action.shift
+      }
+      return next
+    },
+  )
+
+  // Build requested days off lookup
+  const requestedByEmployee = new Map<string, { start_date: string; end_date: string }[]>()
+  for (const r of requestedDaysOff) {
+    if (!requestedByEmployee.has(r.employee_id)) requestedByEmployee.set(r.employee_id, [])
+    requestedByEmployee.get(r.employee_id)!.push(r)
+  }
+
+  function isRecurringOff(emp: Employee, date: string): boolean {
+    const dow = new Date(date + 'T12:00:00Z').getUTCDay()
+    return emp.recurring_days_off.some((r) => r.day_of_week === dow)
+  }
+
+  function isRequestedOff(empId: string, date: string): boolean {
+    return (requestedByEmployee.get(empId) ?? []).some(
+      (r) => r.start_date <= date && date <= r.end_date,
+    )
+  }
+
+  async function handleLock(date: string) {
+    startTransition(async () => {
+      const result = await lockDate(date)
+      if (result.error) alert(result.error)
+      else router.refresh()
+    })
+  }
+
+  async function handleUnlock(date: string) {
+    startTransition(async () => {
+      const result = await unlockDate(date)
+      if (result.error) alert(result.error)
+      else router.refresh()
+    })
+  }
+
+  async function handleSelect(empId: string, date: string, value: string | 'off' | 'clear') {
+    const key = `${empId}:${date}`
+    setActiveCell(null)
+
+    startTransition(async () => {
+      if (value === 'clear') {
+        applyOptimistic({ key, shift: null })
+        const result = await deleteShift(empId, date)
+        if (result.error) alert(result.error)
+      } else if (value === 'off') {
+        const optimistic: Shift = {
+          id: '',
+          employee_id: empId,
+          shift_date: date,
+          start_time: null,
+          is_off: true,
+          status: 'draft',
+        }
+        applyOptimistic({ key, shift: optimistic })
+        const result = await upsertShift(empId, date, { isOff: true })
+        if (result.error) alert(result.error)
+      } else {
+        const optimistic: Shift = {
+          id: '',
+          employee_id: empId,
+          shift_date: date,
+          start_time: toDbTime(value),
+          is_off: false,
+          status: 'draft',
+        }
+        applyOptimistic({ key, shift: optimistic })
+        const result = await upsertShift(empId, date, { startTime: toDbTime(value) })
+        if (result.error) alert(result.error)
+      }
+      router.refresh()
+    })
+  }
+
+  function navigate(direction: 'prev' | 'next') {
+    const d = new Date(startDate + 'T12:00:00Z')
+    d.setUTCDate(d.getUTCDate() + (direction === 'next' ? 7 : -7))
+    router.push(`/shifts?date=${d.toISOString().slice(0, 10)}`)
+  }
+
+  function goToDate(offsetDays: number) {
+    const d = new Date()
+    d.setDate(d.getDate() + offsetDays)
+    router.push(`/shifts?date=${d.toISOString().slice(0, 10)}`)
+  }
+
+  // Determine active cell info for the bottom panel
+  const activeParts = activeCell ? activeCell.split(':') : null
+  const activeEmpId = activeParts ? activeParts[0] : null
+  const activeDate = activeParts ? activeParts.slice(1).join(':') : null
+  const activeEmp = activeEmpId ? employees.find((e) => e.id === activeEmpId) : null
+  const activeShift = activeCell ? optimisticMap[activeCell] ?? null : null
+
+  return (
+    <div className="space-y-3">
+      {/* Navigation */}
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          onClick={() => navigate('prev')}
+          className="rounded border border-zinc-300 px-3 py-1.5 text-sm hover:bg-zinc-100"
+        >
+          ← 前週
+        </button>
+        <button
+          onClick={() => goToDate(0)}
+          className="rounded border border-zinc-300 px-3 py-1.5 text-sm hover:bg-zinc-100"
+        >
+          今日
+        </button>
+        <button
+          onClick={() => goToDate(1)}
+          className="rounded border border-zinc-300 px-3 py-1.5 text-sm hover:bg-zinc-100"
+        >
+          明日
+        </button>
+        <button
+          onClick={() => navigate('next')}
+          className="rounded border border-zinc-300 px-3 py-1.5 text-sm hover:bg-zinc-100"
+        >
+          次週 →
+        </button>
+        {isPending && <span className="text-xs text-zinc-400">更新中…</span>}
+      </div>
+
+      {/* Grid */}
+      <div className="overflow-auto rounded border border-zinc-200">
+        <table className="border-collapse text-sm">
+          <thead>
+            <tr>
+              <th className="sticky left-0 z-20 min-w-28 border-b border-r border-zinc-200 bg-white px-3 py-2 text-left text-xs font-medium text-zinc-500">
+                従業員
+              </th>
+              {dates.map((date) => {
+                const { label, dow } = formatDateHeader(date)
+                const color =
+                  dow === 0
+                    ? 'text-red-500'
+                    : dow === 6
+                      ? 'text-blue-500'
+                      : 'text-zinc-700'
+                const isLocked = lockedSet.has(date)
+                const isEditableDate = date === today || date === tomorrow
+                return (
+                  <th
+                    key={date}
+                    className={`sticky top-0 z-10 min-w-24 border-b border-r border-zinc-200 px-2 py-2 text-center text-xs font-medium whitespace-nowrap ${isLocked ? 'bg-zinc-50' : 'bg-white'}`}
+                  >
+                    <div className="flex flex-col items-center gap-1">
+                      <span className={color}>{label}</span>
+                      {isLocked ? (
+                        <button
+                          onClick={() => handleUnlock(date)}
+                          disabled={isPending}
+                          className="flex items-center gap-0.5 rounded px-1.5 py-0.5 text-xs text-zinc-400 hover:bg-red-50 hover:text-red-500 disabled:opacity-50"
+                        >
+                          🔒 解除
+                        </button>
+                      ) : isEditableDate ? (
+                        <button
+                          onClick={() => handleLock(date)}
+                          disabled={isPending}
+                          className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-white hover:bg-zinc-600 disabled:opacity-50"
+                        >
+                          確定
+                        </button>
+                      ) : null}
+                    </div>
+                  </th>
+                )
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {employees.map((emp) => (
+              <tr key={emp.id}>
+                <td className="sticky left-0 z-10 border-b border-r border-zinc-200 bg-white px-3 py-2">
+                  <div className="font-medium text-zinc-900">{emp.name}</div>
+                  {emp.weekly_hour_limit != null && (
+                    <div className="text-xs text-zinc-400">週{emp.weekly_hour_limit}h上限</div>
+                  )}
+                </td>
+                {dates.map((date) => {
+                  const key = `${emp.id}:${date}`
+                  const shift = optimisticMap[key] ?? null
+                  const recurringOff = isRecurringOff(emp, date)
+                  const requestedOff = isRequestedOff(emp.id, date)
+                  const isActive = activeCell === key
+                  const isLocked = lockedSet.has(date)
+                  const isEditable = (date === today || date === tomorrow) && !isLocked
+
+                  let bgClass = 'bg-white'
+                  if (recurringOff) bgClass = 'bg-zinc-100'
+                  else if (requestedOff) bgClass = isEditable ? 'bg-blue-50 hover:bg-blue-100' : 'bg-blue-50'
+                  else if (isEditable) bgClass = 'bg-white hover:bg-zinc-50'
+
+                  return (
+                    <td
+                      key={date}
+                      className={`border-b border-r border-zinc-200 px-1 py-1 text-center ${bgClass} ${isActive ? 'ring-2 ring-inset ring-zinc-400' : ''}`}
+                    >
+                      <button
+                        onClick={() => isEditable && !recurringOff && setActiveCell(isActive ? null : key)}
+                        disabled={!isEditable || recurringOff || isPending}
+                        className="flex h-8 w-full items-center justify-center rounded text-xs disabled:cursor-default"
+                      >
+                        {shift ? (
+                          shift.is_off ? (
+                            <span className={`font-medium ${isEditable ? 'text-red-500' : 'text-red-300'}`}>休み</span>
+                          ) : (
+                            <span className={`font-medium ${isEditable ? 'text-zinc-900' : 'text-zinc-400'}`}>
+                              {formatTime(shift.start_time!)}
+                            </span>
+                          )
+                        ) : recurringOff ? (
+                          <span className="text-zinc-300">定休</span>
+                        ) : requestedOff ? (
+                          <span className="text-blue-300 text-xs">オフ申請</span>
+                        ) : (
+                          <span className="text-zinc-300">—</span>
+                        )}
+                      </button>
+                    </td>
+                  )
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Legend */}
+      <div className="flex flex-wrap gap-4 text-xs text-zinc-500">
+        <span className="flex items-center gap-1.5">
+          <span className="h-3 w-3 rounded border border-zinc-200 bg-zinc-100" />
+          定期休み
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="h-3 w-3 rounded border border-blue-100 bg-blue-50" />
+          オフ申請中
+        </span>
+      </div>
+
+      {/* Bottom panel for cell editing */}
+      {activeCell && activeEmp && activeDate && (
+        <>
+          <div
+            className="fixed inset-0 z-40"
+            onClick={() => setActiveCell(null)}
+            aria-hidden="true"
+          />
+          <div className="fixed bottom-0 left-0 right-0 z-50 border-t border-zinc-200 bg-white p-4 shadow-2xl">
+            <div className="mx-auto max-w-sm space-y-3">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-zinc-900">
+                  {activeEmp.name}
+                  <span className="ml-2 font-normal text-zinc-500">
+                    {formatDateHeader(activeDate).label}
+                  </span>
+                </span>
+                <button
+                  onClick={() => setActiveCell(null)}
+                  className="text-sm text-zinc-400 hover:text-zinc-600"
+                >
+                  ✕
+                </button>
+              </div>
+
+              <div className="grid grid-cols-3 gap-2">
+                {PRESET_TIMES.map((t) => {
+                  const isSelected =
+                    activeShift !== null &&
+                    !activeShift.is_off &&
+                    activeShift.start_time !== null &&
+                    formatTime(activeShift.start_time) === t
+                  const isManagerDefault =
+                    activeShift === null && activeEmp.is_manager && t === '9:00'
+                  return (
+                    <button
+                      key={t}
+                      onClick={() => handleSelect(activeEmp.id, activeDate, t)}
+                      className={`rounded border py-2 text-sm font-medium transition-colors ${
+                        isSelected
+                          ? 'border-zinc-900 bg-zinc-900 text-white'
+                          : isManagerDefault
+                            ? 'border-zinc-400 bg-zinc-100'
+                            : 'border-zinc-300 hover:bg-zinc-50'
+                      }`}
+                    >
+                      {t}
+                    </button>
+                  )
+                })}
+                <button
+                  onClick={() => handleSelect(activeEmp.id, activeDate, 'off')}
+                  className={`rounded border py-2 text-sm font-medium transition-colors ${
+                    activeShift?.is_off
+                      ? 'border-red-600 bg-red-600 text-white'
+                      : 'border-red-300 text-red-600 hover:bg-red-50'
+                  }`}
+                >
+                  休み
+                </button>
+                {activeShift && (
+                  <button
+                    onClick={() => handleSelect(activeEmp.id, activeDate, 'clear')}
+                    className="rounded border border-zinc-200 py-2 text-sm text-zinc-400 hover:bg-zinc-50"
+                  >
+                    クリア
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/lib/auth/shortcut.ts
+++ b/lib/auth/shortcut.ts
@@ -1,0 +1,10 @@
+export function verifyShortcutToken(request: Request): boolean {
+  const authHeader = request.headers.get('Authorization')
+  if (!authHeader?.startsWith('Bearer ')) return false
+
+  const token = authHeader.slice(7)
+  const expected = process.env.SHORTCUT_API_TOKEN
+  if (!expected) return false
+
+  return token === expected
+}

--- a/supabase/migrations/20260615000000_add_is_manager_to_employees.sql
+++ b/supabase/migrations/20260615000000_add_is_manager_to_employees.sql
@@ -1,0 +1,2 @@
+alter table public.employees
+  add column is_manager boolean not null default false;

--- a/supabase/migrations/20260615000001_add_shift_locks.sql
+++ b/supabase/migrations/20260615000001_add_shift_locks.sql
@@ -1,0 +1,10 @@
+create table public.shift_locks (
+  shift_date  date        primary key,
+  locked_at   timestamptz not null default now()
+);
+
+alter table public.shift_locks enable row level security;
+
+create policy "managers_full_access_shift_locks"
+  on public.shift_locks for all to authenticated
+  using (true) with check (true);


### PR DESCRIPTION
Closes #13

## Summary

Implements the API through which the iOS Shortcut fetches shift data and reports send completion.

## Endpoints

### `GET /api/shifts/messages?date=YYYY-MM-DD`
Generates and returns each employee's message from the shifts on the given date.

**Example response:**
```json
{
  "date": "2026-06-16",
  "messages": [
    { "phone": "+16041234567", "body": "明日 6/16 (月) は 9:00 からです。", "shift_id": "uuid" },
    { "phone": "+16049876543", "body": "明日 6/16 (月) はお休みです。", "shift_id": "uuid" }
  ]
}
```

### `POST /api/shifts/messages/sent`
Reports SMS send completion. Updates the shift status to `sent` and records it in `message_logs`.

**Request body:**
```json
{ "shift_id": "uuid", "message_body": "..." }
```

## Authentication

Authenticated via the `Authorization: Bearer <SHORTCUT_API_TOKEN>` header. Unauthorized requests get a 401.

## Configuration

- Added `SHORTCUT_API_TOKEN` to `.env.local` (randomly generated)
- The same value must also be set in Vercel's environment variables

## Test plan

- [ ] GET with the correct token → 200 and a messages array
- [ ] GET with a wrong token → 401
- [ ] GET without the `date` parameter → 400
- [ ] POST with the correct token → 200, the shift's status becomes sent, recorded in message_logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)