### PR TITLE
fix: shortcut API - exclude from middleware auth, introduce service role client (#13/#14)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
 # iOSショートカット認証用トークン（任意の長いランダム文字列）
 SHORTCUT_API_TOKEN=your-secret-token
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key

--- a/app/(dashboard)/shifts/actions.ts
+++ b/app/(dashboard)/shifts/actions.ts
@@ -12,24 +12,14 @@ export async function upsertShift(
   await requireManager()
 
   const supabase = await createClient()
-  const row =
-    'isOff' in payload
-      ? {
-          employee_id: employeeId,
-          shift_date: shiftDate,
-          is_off: true,
-          start_time: null,
-          status: 'draft',
-          updated_at: new Date().toISOString(),
-        }
-      : {
-          employee_id: employeeId,
-          shift_date: shiftDate,
-          is_off: false,
-          start_time: payload.startTime,
-          status: 'draft',
-          updated_at: new Date().toISOString(),
-        }
+  const row = {
+    employee_id: employeeId,
+    shift_date: shiftDate,
+    is_off: 'isOff' in payload,
+    start_time: 'isOff' in payload ? null : payload.startTime,
+    status: 'draft',
+    updated_at: new Date().toISOString(),
+  }
 
   const { error } = await supabase
     .from('shifts')

--- a/app/api/shifts/messages/route.ts
+++ b/app/api/shifts/messages/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
 import { verifyShortcutToken } from '@/lib/auth/shortcut'
 import { renderTemplate } from '@/lib/utils/render-template'
 
@@ -26,7 +26,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'date パラメータが必要です (YYYY-MM-DD)' }, { status: 400 })
   }
 
-  const supabase = await createClient()
+  const supabase = createAdminClient()
 
   const [{ data: shifts, error: shiftsError }, { data: templates, error: templatesError }] =
     await Promise.all([

--- a/app/api/shifts/messages/sent/route.ts
+++ b/app/api/shifts/messages/sent/route.ts
@@ -20,10 +20,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     typeof (body as Record<string, unknown>).shift_id !== 'string' ||
     typeof (body as Record<string, unknown>).message_body !== 'string'
   ) {
-    return NextResponse.json(
-      { error: 'shift_id と message_body が必要です' },
-      { status: 400 },
-    )
+    return NextResponse.json({ error: 'shift_id と message_body が必要です' }, { status: 400 })
   }
 
   const { shift_id, message_body } = body as { shift_id: string; message_body: string }
@@ -39,9 +36,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'シフトステータスの更新に失敗しました' }, { status: 500 })
   }
 
-  const { error: logError } = await supabase
-    .from('message_logs')
-    .insert({ shift_id, message_body })
+  const { error: logError } = await supabase.from('message_logs').insert({ shift_id, message_body })
 
   if (logError) {
     return NextResponse.json({ error: '送信ログの記録に失敗しました' }, { status: 500 })

--- a/app/api/shifts/messages/sent/route.ts
+++ b/app/api/shifts/messages/sent/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
 import { verifyShortcutToken } from '@/lib/auth/shortcut'
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
@@ -28,7 +28,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   const { shift_id, message_body } = body as { shift_id: string; message_body: string }
 
-  const supabase = await createClient()
+  const supabase = createAdminClient()
 
   const { error: updateError } = await supabase
     .from('shifts')

--- a/lib/supabase/admin.ts
+++ b/lib/supabase/admin.ts
@@ -1,0 +1,11 @@
+import { createClient } from '@supabase/supabase-js'
+
+// ショートカットAPI専用の特権クライアント。
+// RLSをバイパスするため、SHORTCUT_API_TOKEN検証済みのルートでのみ使用すること。
+export function createAdminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  )
+}

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -8,6 +8,7 @@ const PUBLIC_PATHS = [
   '/test-connection',
   '/auth/confirm',
   '/schedule',
+  '/api/shifts/messages', // iOSショートカット用API（route側でBearerトークン検証）
 ]
 
 function isPublicPath(pathname: string): boolean {


### PR DESCRIPTION
## Summary
Fixes two issues that prevented the iOS Shortcut API (implemented in #13) from actually working:
requests from the Shortcut were being redirected to /login by the middleware,
and RLS prevented the anonymous client from reading message_templates, leaving message bodies empty.

Related: #13, #14

## Changes
- `lib/supabase/middleware.ts`: added `/api/shifts/messages` to PUBLIC_PATHS (Bearer token is verified on the route side)
- Added `lib/supabase/admin.ts`: privileged client using the service role (shortcut API only)
- `app/api/shifts/messages/route.ts`, `.../sent/route.ts`: switched from the cookie-based client to the admin client

## How to Verify
1. Set `SHORTCUT_API_TOKEN` and `SUPABASE_SERVICE_ROLE_KEY` in `.env.local`
2. Start with `npm run dev`
3. Enter one shift, Confirm it, and set up a template
4. `curl -H "Authorization: Bearer $SHORTCUT_API_TOKEN" "http://localhost:3000/api/shifts/messages?date=YYYY-MM-DD"`
5. Confirm phone / body (with template variables substituted) / shift_id are returned

## Screenshots / Notes
- The service role client bypasses RLS, so it must only be used in routes that have passed `verifyShortcutToken`
- Verified locally with curl

## Checklist
- [x] `npm run lint` passes (0 errors / 1 pre-existing warning in an unrelated file)
- [x] `npm run build` passes
- [x] `npm run format:check` passes (for my changes; warnings on 5 pre-existing files are a separate matter)
- [x] New environment variable added → `.env.example` updated (`SUPABASE_SERVICE_ROLE_KEY`)
- [x] No DB schema changes (no new migrations)
- [x] No existing migrations edited
- [x] No personal information (phone numbers, real names, etc.) in logs or test data