### PR TITLE
fix: exclude off-day shifts from SMS notification targets

### DIFF
--- a/app/api/shifts/messages/route.ts
+++ b/app/api/shifts/messages/route.ts
@@ -33,7 +33,8 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       supabase
         .from('shifts')
         .select('id, start_time, is_off, employees(name, phone)')
-        .eq('shift_date', date),
+        .eq('shift_date', date)
+        .eq('is_off', false),
       supabase.from('message_templates').select('type, body'),
     ])
 


### PR DESCRIPTION
## Summary

Excludes off (is_off) shifts from SMS notification targets.
This matches the operational policy of not notifying employees on requested or recurring days off (per the manager's request).

## Changes

- `app/api/shifts/messages/route.ts`: added `.eq('is_off', false)` to the shifts query
- The off template (`off`) is kept for future use (it becomes unused by this API)

## How to Verify

1. Create one attending shift and one off shift on the same date and Confirm
2. Hit `GET /api/shifts/messages?date=YYYY-MM-DD` with the Bearer token
3. Confirm that only the attending employee appears in `messages`

## Checklist

- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] `npm run format:check` passes (for my changes; warnings on 5 pre-existing files are a separate matter)
- [x] No new environment variables
- [x] No DB schema changes (no new migrations)
- [x] No existing migrations edited
- [x] No personal information (phone numbers, real names, etc.) in logs or test data

## Screenshots / Notes

- Confirmed `npm run build` succeeds locally
- Employees without a shift row remain excluded from notifications as before (this change only excludes is_off rows)