### PR TITLE
fix: skip SMS notifications only for requested/recurring days off

### DIFF
--- a/app/api/shifts/messages/route.ts
+++ b/app/api/shifts/messages/route.ts
@@ -33,7 +33,8 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       supabase
         .from('shifts')
         .select('id, start_time, is_off, employees(name, phone)')
-        .eq('shift_date', date),
+        .eq('shift_date', date)
+        .eq('is_off', false),
       supabase.from('message_templates').select('type, body'),
     ])
 

--- a/app/api/shifts/messages/route.ts
+++ b/app/api/shifts/messages/route.ts
@@ -27,26 +27,43 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   }
 
   const supabase = createAdminClient()
+  const dayOfWeek = new Date(date + 'T12:00:00Z').getUTCDay()
 
-  const [{ data: shifts, error: shiftsError }, { data: templates, error: templatesError }] =
-    await Promise.all([
-      supabase
-        .from('shifts')
-        .select('id, start_time, is_off, employees(name, phone)')
-        .eq('shift_date', date)
-        .eq('is_off', false),
-      supabase.from('message_templates').select('type, body'),
-    ])
+  const [
+    { data: shifts, error: shiftsError },
+    { data: templates, error: templatesError },
+    { data: requestedOff, error: requestedError },
+    { data: recurringOff, error: recurringError },
+  ] = await Promise.all([
+    supabase
+      .from('shifts')
+      .select('id, employee_id, start_time, is_off, employees(name, phone)')
+      .eq('shift_date', date),
+    supabase.from('message_templates').select('type, body'),
+    supabase
+      .from('requested_days_off')
+      .select('employee_id')
+      .lte('start_date', date)
+      .gte('end_date', date),
+    supabase.from('recurring_days_off').select('employee_id').eq('day_of_week', dayOfWeek),
+  ])
 
-  if (shiftsError || templatesError) {
+  if (shiftsError || templatesError || requestedError || recurringError) {
     return NextResponse.json({ error: 'データの取得に失敗しました' }, { status: 500 })
   }
+
+  // 本人が申請済みのオフ（リクエストオフ・定期オフ）は通知不要
+  const knownOffEmployeeIds = new Set([
+    ...(requestedOff ?? []).map((r) => r.employee_id),
+    ...(recurringOff ?? []).map((r) => r.employee_id),
+  ])
 
   const attendTemplate = templates?.find((t) => t.type === 'attend')?.body ?? ''
   const offTemplate = templates?.find((t) => t.type === 'off')?.body ?? ''
   const dateLabel = formatMessageDate(date)
 
   const messages = (shifts ?? [])
+    .filter((shift) => !(shift.is_off && knownOffEmployeeIds.has(shift.employee_id)))
     .map((shift) => {
       const employee = Array.isArray(shift.employees) ? shift.employees[0] : shift.employees
       if (!employee) return null


### PR DESCRIPTION
## Summary

Excludes from SMS notifications only the off shifts that correspond to requested or recurring days off (per the manager's operational request).
Days off the employee already requested need no notification. Days off assigned by the store, on the other hand, still get the "you're off" notification as before.

## Changes

- `app/api/shifts/messages/route.ts`:
  - Fetches `requested_days_off` (target date within the range) and `recurring_days_off` (same weekday as the target date)
  - Excludes matching employees' is_off shifts from the notification targets
  - Off shifts without a request are still notified with the off template as before
  - No change to how attending shifts and employees without a shift row are handled

## How to Verify

1. Create the following 3 cases on the same date and Confirm:
   an employee with an attending shift / an employee OFF with a registered requested day off / an employee OFF without any request
2. Hit `GET /api/shifts/messages?date=YYYY-MM-DD` with the Bearer token
3. Confirm that only the attending employee (attendance template) and the no-request OFF employee (off template) appear in `messages`, and the requested-day-off employee does not

## Checklist

- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] `npm run format:check` passes (for my changes; warnings on pre-existing files are a separate matter)
- [x] No new environment variables
- [x] No DB schema changes (no new migrations)
- [x] No existing migrations edited
- [x] No personal information (phone numbers, real names, etc.) in logs or test data

## Screenshots / Notes

- Confirmed `npm run build` succeeds locally
- Employees with recurring days off usually have no shift row because their grid cells are non-editable, so in practice the exclusion mainly applies to requested days off
- Weekday determination uses the same UTC-noon basis (getUTCDay) as the existing formatMessageDate