### PR TITLE
fix: use English day-of-week labels in SMS messages

### DIFF
--- a/app/api/shifts/messages/route.ts
+++ b/app/api/shifts/messages/route.ts
@@ -3,7 +3,7 @@ import { createAdminClient } from '@/lib/supabase/admin'
 import { verifyShortcutToken } from '@/lib/auth/shortcut'
 import { renderTemplate } from '@/lib/utils/render-template'
 
-const DAY_LABELS = ['日', '月', '火', '水', '木', '金', '土'] as const
+const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const
 
 function formatMessageDate(date: string): string {
   const d = new Date(date + 'T12:00:00Z')


### PR DESCRIPTION
## Summary
Changes the day-of-week labels in SMS bodies from Japanese (木・金) to English (Thu・Fri), matching the English localization of the templates.

## Changes
- `app/api/shifts/messages/route.ts`: changed DAY_LABELS to 3-letter English labels

## Checklist
- [x] `npm run build` passes
- [x] No environment variable or DB schema changes
- [x] No personal information