### PR TITLE
feat: add SMS shortcut launch button on confirmed dates

### DIFF
--- a/components/features/shift-grid.tsx
+++ b/components/features/shift-grid.tsx
@@ -249,13 +249,21 @@ export function ShiftGrid({
                     <div className="flex flex-col items-center gap-1">
                       <span className={color}>{label}</span>
                       {isLocked && !isPast ? (
-                        <button
-                          onClick={() => handleUnlock(date)}
-                          disabled={isPending}
-                          className="flex items-center gap-0.5 rounded px-1.5 py-0.5 text-xs text-zinc-400 hover:bg-red-50 hover:text-red-500 disabled:opacity-50"
-                        >
-                          🔒 Unlock
-                        </button>
+                        <div className="flex items-center gap-1">
+                          <button
+                            onClick={() => handleUnlock(date)}
+                            disabled={isPending}
+                            className="flex items-center gap-0.5 rounded px-1.5 py-0.5 text-xs text-zinc-400 hover:bg-red-50 hover:text-red-500 disabled:opacity-50"
+                          >
+                            🔒 Unlock
+                          </button>
+                          <a
+                            href={`shortcuts://run-shortcut?name=${encodeURIComponent('シフトSMS送信')}&input=text&text=${date}`}
+                            className="rounded bg-emerald-600 px-1.5 py-0.5 text-xs text-white hover:bg-emerald-500"
+                          >
+                            📱 SMS
+                          </a>
+                        </div>
                       ) : isEditableDate && !isLocked ? (
                         <button
                           onClick={() => handleLock(date)}


### PR DESCRIPTION
## Summary
Adds a "📱 SMS" button to confirmed date columns. Tapping it in Safari on the iPhone
launches the shift SMS sending Shortcut (the manager operates from an iPhone only).

## Changes
- `components/features/shift-grid.tsx`: added a link button to shortcuts://run-shortcut
  on the header of locked, non-past dates (passes the confirmed date as input)

## How to Verify
1. Log into production in Safari on an iPhone and open Shifts
2. Tap "📱 SMS" on a confirmed column
3. Confirm the shift SMS sending shortcut launches in the Shortcuts app

## Checklist
- [x] `npm run build` passes
- [x] No environment variable or DB schema changes
- [x] No personal information