### PR TITLE
feat: order employees by display_order (whiteboard order)

### DIFF
--- a/app/(dashboard)/days-off/[id]/edit/page.tsx
+++ b/app/(dashboard)/days-off/[id]/edit/page.tsx
@@ -17,7 +17,7 @@ export default async function EditDaysOffPage({ params }: { params: Promise<{ id
       .select('id, employee_id, start_date, end_date, reason')
       .eq('id', id)
       .single(),
-    supabase.from('employees').select('id, name').eq('is_active', true).order('name'),
+    supabase.from('employees').select('id, name').eq('is_active', true).order('display_order').order('name'),
   ])
 
   if (!daysOff) notFound()

--- a/app/(dashboard)/days-off/new/page.tsx
+++ b/app/(dashboard)/days-off/new/page.tsx
@@ -12,7 +12,7 @@ export default async function NewDaysOffPage() {
     .from('employees')
     .select('id, name')
     .eq('is_active', true)
-    .order('name')
+    .order('display_order').order('name')
 
   return (
     <div className="space-y-6">

--- a/app/(dashboard)/employees/page.tsx
+++ b/app/(dashboard)/employees/page.tsx
@@ -41,7 +41,7 @@ export default async function EmployeesPage({
     .select(
       'id, name, phone, visa_type, weekly_hour_limit, is_active, recurring_days_off(day_of_week)',
     )
-    .order('name')
+    .order('display_order').order('name')
 
   if (currentStatus === 'active') query = query.eq('is_active', true)
   else if (currentStatus === 'archived') query = query.eq('is_active', false)

--- a/app/(dashboard)/shifts/page.tsx
+++ b/app/(dashboard)/shifts/page.tsx
@@ -56,7 +56,7 @@ export default async function ShiftsPage({
       .from('employees')
       .select('id, name, notes, weekly_hour_limit, is_manager, recurring_days_off(day_of_week)')
       .eq('is_active', true)
-      .order('name'),
+      .order('display_order').order('name'),
     supabase
       .from('requested_days_off')
       .select('employee_id, start_date, end_date')

--- a/app/schedule/page.tsx
+++ b/app/schedule/page.tsx
@@ -56,7 +56,7 @@ export default async function PublicSchedulePage() {
       .select('shift_date')
       .gte('shift_date', rangeStart)
       .order('shift_date', { ascending: true }),
-    supabase.from('employees').select('id, name').order('name'),
+    supabase.from('employees').select('id, name').order('display_order').order('name'),
   ])
 
   const lockedDates: string[] = (locks ?? []).map((l) => l.shift_date as string)

--- a/supabase/migrations/20260703000000_add_employee_display_order.sql
+++ b/supabase/migrations/20260703000000_add_employee_display_order.sql
@@ -1,0 +1,2 @@
+alter table employees
+  add column if not exists display_order integer not null default 999;


### PR DESCRIPTION
## Summary
Changes the employee display order from alphabetical to the display_order column (same order as the store's whiteboard).

## Changes
- `supabase/migrations/20260703000000_add_employee_display_order.sql`: adds the display_order column (default 999)
- 5 pages — shifts / employees / schedule / days-off (new & edit): ordering changed to display_order → name

## Checklist
- [x] `npm run build` passes
- [x] DB schema changed → added under migrations/, no existing migrations edited
- [x] No personal information