### PR TITLE
Auto-fill manager 9:00 default on confirm, exclude managers from SMS

### DIFF
--- a/app/(dashboard)/shifts/[date]/messages/page.tsx
+++ b/app/(dashboard)/shifts/[date]/messages/page.tsx
@@ -17,11 +17,13 @@ function formatTime(t: string): string {
   return `${parseInt(h, 10)}:${m}`
 }
 
+type EmployeeInfo = { name: string; is_manager: boolean }
+
 type ShiftWithEmployee = {
   id: string
   start_time: string | null
   is_off: boolean
-  employees: { name: string } | { name: string }[] | null
+  employees: EmployeeInfo | EmployeeInfo[] | null
 }
 
 export default async function MessagesPreviewPage({
@@ -41,7 +43,7 @@ export default async function MessagesPreviewPage({
     supabase.from('shift_locks').select('shift_date').eq('shift_date', date).single(),
     supabase
       .from('shifts')
-      .select('id, start_time, is_off, employees(name)')
+      .select('id, start_time, is_off, employees(name, is_manager)')
       .eq('shift_date', date)
       .order('start_time', { ascending: true, nullsFirst: false }),
     supabase.from('message_templates').select('type, body'),
@@ -57,6 +59,8 @@ export default async function MessagesPreviewPage({
     .map((shift: ShiftWithEmployee) => {
       const emp = Array.isArray(shift.employees) ? shift.employees[0] : shift.employees
       if (!emp) return null
+      // マネージャーにはSMSを送らないため、プレビューにも表示しない
+      if (emp.is_manager) return null
 
       const body = shift.is_off
         ? renderTemplate(offTemplate, { date: dateLabel })
@@ -92,7 +96,7 @@ export default async function MessagesPreviewPage({
             {ordered.map((m, i) => (
               <div key={i} className="rounded border border-zinc-200 p-4">
                 <div className="mb-1.5 text-sm font-semibold text-zinc-900">{m.name}</div>
-                <div className="whitespace-pre-wrap text-sm text-zinc-700">{m.body}</div>
+                <div className="text-sm whitespace-pre-wrap text-zinc-700">{m.body}</div>
               </div>
             ))}
           </div>

--- a/app/(dashboard)/shifts/actions.ts
+++ b/app/(dashboard)/shifts/actions.ts
@@ -36,6 +36,55 @@ export async function lockDate(shiftDate: string): Promise<{ error?: string }> {
   await requireManager()
 
   const supabase = await createClient()
+
+  // Managers default to a 9:00 shift. Materialize the default for any manager
+  // who has no shift entry and no requested/recurring day off on this date,
+  // so the confirmed schedule always reflects it. Manual entries (including
+  // Off) and time off always take precedence — they are never overwritten.
+  const dayOfWeek = new Date(shiftDate + 'T12:00:00Z').getUTCDay()
+  const [
+    { data: managers, error: managersError },
+    { data: existingShifts, error: shiftsError },
+    { data: requestedOff, error: requestedError },
+    { data: recurringOff, error: recurringError },
+  ] = await Promise.all([
+    supabase.from('employees').select('id').eq('is_manager', true).eq('is_active', true),
+    supabase.from('shifts').select('employee_id').eq('shift_date', shiftDate),
+    supabase
+      .from('requested_days_off')
+      .select('employee_id')
+      .lte('start_date', shiftDate)
+      .gte('end_date', shiftDate),
+    supabase.from('recurring_days_off').select('employee_id').eq('day_of_week', dayOfWeek),
+  ])
+
+  if (managersError || shiftsError || requestedError || recurringError) {
+    return { error: 'Failed to confirm' }
+  }
+
+  const skipIds = new Set([
+    ...(existingShifts ?? []).map((s) => s.employee_id as string),
+    ...(requestedOff ?? []).map((r) => r.employee_id as string),
+    ...(recurringOff ?? []).map((r) => r.employee_id as string),
+  ])
+
+  const defaultRows = (managers ?? [])
+    .filter((m) => !skipIds.has(m.id as string))
+    .map((m) => ({
+      employee_id: m.id as string,
+      shift_date: shiftDate,
+      is_off: false,
+      start_time: '09:00:00',
+      note: null,
+      status: 'draft',
+      updated_at: new Date().toISOString(),
+    }))
+
+  if (defaultRows.length > 0) {
+    const { error: insertError } = await supabase.from('shifts').insert(defaultRows)
+    if (insertError) return { error: 'Failed to confirm' }
+  }
+
   const { error } = await supabase
     .from('shift_locks')
     .upsert({ shift_date: shiftDate }, { onConflict: 'shift_date' })

--- a/app/api/shifts/messages/route.ts
+++ b/app/api/shifts/messages/route.ts
@@ -37,7 +37,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   ] = await Promise.all([
     supabase
       .from('shifts')
-      .select('id, employee_id, start_time, is_off, employees(name, phone)')
+      .select('id, employee_id, start_time, is_off, employees(name, phone, is_manager)')
       .eq('shift_date', date),
     supabase.from('message_templates').select('type, body'),
     supabase
@@ -67,6 +67,8 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     .map((shift) => {
       const employee = Array.isArray(shift.employees) ? shift.employees[0] : shift.employees
       if (!employee) return null
+      // マネージャーにはSMSを送らない（デフォルト9:00・手動入力・Offいずれも対象外）
+      if (employee.is_manager) return null
 
       const body = shift.is_off
         ? renderTemplate(offTemplate, { date: dateLabel })

--- a/components/features/employee-form.tsx
+++ b/components/features/employee-form.tsx
@@ -17,6 +17,7 @@ interface EmployeeFormProps {
     visa_type?: string | null
     weekly_hour_limit?: number | null
     notes?: string | null
+    is_manager?: boolean
   }
   defaultOffDays?: number[]
 }
@@ -28,6 +29,7 @@ export function EmployeeForm({
 }: EmployeeFormProps) {
   const [state, formAction] = useActionState(action, {})
   const [offDays, setOffDays] = useState(new Set(defaultOffDays))
+  const [isManager, setIsManager] = useState(defaultValues.is_manager ?? false)
 
   const [fields, setFields] = useState({
     name: defaultValues.name ?? '',
@@ -82,7 +84,9 @@ export function EmployeeForm({
           placeholder="+16041234567"
           className="w-full rounded border border-zinc-400 px-3 py-2 text-sm focus:border-zinc-700 focus:outline-none"
         />
-        <p className="text-xs text-zinc-500">E.164 format starting with +1 (11 digits, no hyphens)</p>
+        <p className="text-xs text-zinc-500">
+          E.164 format starting with +1 (11 digits, no hyphens)
+        </p>
         {state.fieldErrors?.phone && (
           <p className="text-xs text-red-600">{state.fieldErrors.phone}</p>
         )}
@@ -163,6 +167,23 @@ export function EmployeeForm({
             </label>
           ))}
         </div>
+      </div>
+
+      <div className="space-y-1">
+        <label className="flex items-center gap-2 text-sm font-medium">
+          <input
+            type="checkbox"
+            name="is_manager"
+            value="true"
+            checked={isManager}
+            onChange={(e) => setIsManager(e.target.checked)}
+            className="h-4 w-4 rounded border-zinc-400"
+          />
+          Manager
+        </label>
+        <p className="text-xs text-zinc-500">
+          Auto-filled with a 9:00 shift on confirm (unless off) and excluded from SMS
+        </p>
       </div>
 
       <button

--- a/components/features/shift-grid.tsx
+++ b/components/features/shift-grid.tsx
@@ -415,6 +415,8 @@ export function ShiftGrid({
                           <span className="text-zinc-300">—</span>
                         ) : requestedOff ? (
                           <span className="text-xs text-blue-300">T/O</span>
+                        ) : emp.is_manager && !isLocked ? (
+                          <span className="font-medium text-zinc-300">9:00</span>
                         ) : (
                           <span className="text-zinc-300">—</span>
                         )}
@@ -437,6 +439,10 @@ export function ShiftGrid({
         <span className="flex items-center gap-1.5">
           <span className="h-3 w-3 rounded border border-blue-100 bg-blue-50" />
           Time off requested
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="font-medium text-zinc-300">9:00</span>
+          Manager default (auto-filled on confirm)
         </span>
       </div>
 


### PR DESCRIPTION
## What

Managers work a fixed 9:00 start, so entering it manually every day was pure friction. Now:

- **Confirm-time materialization**: when a date is confirmed (`lockDate`), a 9:00 shift row is auto-created for every active manager who has no shift entry, no requested time off, and no recurring day off on that date. Manual entries (including Off) and time off always take precedence and are never overwritten.
- **Ghost preview**: manager cells on unconfirmed dates show a muted `9:00` placeholder in the grid, with a legend entry, so it's clear what will be filled in on confirm.
- **SMS exclusion**: managers are excluded from SMS generation and from the message preview page entirely — they schedule shifts, they don't need to be notified of them.
- **Employee form fix**: the `is_manager` flag existed in the DB (June migration) and the server action already parsed it, but the form never rendered a checkbox — the flag was unsettable via UI, and any edit silently reset it to false. Added the Manager checkbox with an explanatory hint.

## Design decision: materialize on confirm, not on view

Auto-creating rows at confirm time (rather than pre-inserting on page load) keeps the DB free of speculative rows for dates still being edited, and means the public schedule page — which only shows confirmed dates — needed zero changes.

## Migration

None — reuses the existing `is_manager` column.

## Testing

- `tsc --noEmit`, ESLint, Prettier: clean (one pre-existing warning unrelated to this change)
- Existing test suite: 21/21 passing
- Manual: ghost display, confirm-time auto-fill, T/O precedence, SMS preview exclusion, form checkbox persistence