### PR TITLE
chore: translate error messages and test descriptions to English

### DIFF
--- a/app/(dashboard)/employees/actions.ts
+++ b/app/(dashboard)/employees/actions.ts
@@ -98,7 +98,7 @@ export async function updateEmployee(
   await requireManager()
 
   const id = formData.get('id') as string
-  if (!id) return { error: '従業員IDが見つかりません' }
+  if (!id) return { error: 'Employee ID not found' }
 
   const { data, errors } = parseFormData(formData)
   if (errors) return { fieldErrors: errors }

--- a/app/(dashboard)/shifts/actions.ts
+++ b/app/(dashboard)/shifts/actions.ts
@@ -120,7 +120,7 @@ export async function deleteShift(
     .eq('employee_id', employeeId)
     .eq('shift_date', shiftDate)
 
-  if (error) return { error: '削除に失敗しました' }
+  if (error) return { error: 'Failed to delete' }
 
   revalidatePath('/shifts')
   return {}

--- a/app/api/shifts/messages/route.ts
+++ b/app/api/shifts/messages/route.ts
@@ -23,7 +23,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
   const date = request.nextUrl.searchParams.get('date')
   if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
-    return NextResponse.json({ error: 'date パラメータが必要です (YYYY-MM-DD)' }, { status: 400 })
+    return NextResponse.json({ error: 'date parameter is required (YYYY-MM-DD)' }, { status: 400 })
   }
 
   const supabase = createAdminClient()
@@ -49,7 +49,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   ])
 
   if (shiftsError || templatesError || requestedError || recurringError) {
-    return NextResponse.json({ error: 'データの取得に失敗しました' }, { status: 500 })
+    return NextResponse.json({ error: 'Failed to fetch data' }, { status: 500 })
   }
 
   // Days off the employee already requested (requested/recurring) need no notification

--- a/app/api/shifts/messages/sent/route.ts
+++ b/app/api/shifts/messages/sent/route.ts
@@ -11,7 +11,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
     body = await request.json()
   } catch {
-    return NextResponse.json({ error: 'リクエストボディが不正です' }, { status: 400 })
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
   }
 
   if (
@@ -20,7 +20,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     typeof (body as Record<string, unknown>).shift_id !== 'string' ||
     typeof (body as Record<string, unknown>).message_body !== 'string'
   ) {
-    return NextResponse.json({ error: 'shift_id と message_body が必要です' }, { status: 400 })
+    return NextResponse.json({ error: 'shift_id and message_body are required' }, { status: 400 })
   }
 
   const { shift_id, message_body } = body as { shift_id: string; message_body: string }
@@ -33,13 +33,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     .eq('id', shift_id)
 
   if (updateError) {
-    return NextResponse.json({ error: 'シフトステータスの更新に失敗しました' }, { status: 500 })
+    return NextResponse.json({ error: 'Failed to update shift status' }, { status: 500 })
   }
 
   const { error: logError } = await supabase.from('message_logs').insert({ shift_id, message_body })
 
   if (logError) {
-    return NextResponse.json({ error: '送信ログの記録に失敗しました' }, { status: 500 })
+    return NextResponse.json({ error: 'Failed to record send log' }, { status: 500 })
   }
 
   return NextResponse.json({ ok: true })

--- a/lib/utils/render-template.test.ts
+++ b/lib/utils/render-template.test.ts
@@ -2,72 +2,74 @@ import { describe, expect, it } from 'vitest'
 import { renderTemplate } from './render-template'
 
 describe('renderTemplate', () => {
-  describe('変数置換', () => {
-    it('{date} を置換する', () => {
-      expect(renderTemplate('明日 {date} はお休みです', { date: '4月26日(日)' })).toBe(
-        '明日 4月26日(日) はお休みです',
+  describe('variable substitution', () => {
+    it('substitutes {date}', () => {
+      expect(renderTemplate('Tomorrow {date} is your day off', { date: 'Apr 26 (Sun)' })).toBe(
+        'Tomorrow Apr 26 (Sun) is your day off',
       )
     })
 
-    it('{time} を置換する', () => {
+    it('substitutes {time}', () => {
       expect(
-        renderTemplate('{date} は {time} からです', { date: '4月26日(日)', time: '9:00' }),
-      ).toBe('4月26日(日) は 9:00 からです')
+        renderTemplate('{date} starts at {time}', { date: 'Apr 26 (Sun)', time: '9:00' }),
+      ).toBe('Apr 26 (Sun) starts at 9:00')
     })
 
-    it('vars にない変数は原文のまま残す', () => {
-      expect(renderTemplate('今日は {undefined_var} です', {})).toBe('今日は {undefined_var} です')
+    it('leaves variables absent from vars as-is', () => {
+      expect(renderTemplate('Today is {undefined_var}', {})).toBe('Today is {undefined_var}')
     })
 
-    it('値が undefined の変数は原文のまま残す', () => {
-      expect(renderTemplate('{date} は {time} からです', { date: '4月26日(日)' })).toBe(
-        '4月26日(日) は {time} からです',
+    it('leaves variables with undefined values as-is', () => {
+      expect(renderTemplate('{date} starts at {time}', { date: 'Apr 26 (Sun)' })).toBe(
+        'Apr 26 (Sun) starts at {time}',
       )
     })
   })
 
-  describe('エスケープ', () => {
-    it('\\{ を { に変換する', () => {
-      expect(renderTemplate('\\{date\\}', { date: '4月26日(日)' })).toBe('{date}')
+  describe('escaping', () => {
+    it('converts \\{ to {', () => {
+      expect(renderTemplate('\\{date\\}', { date: 'Apr 26 (Sun)' })).toBe('{date}')
     })
 
-    it('\\\\ を \\ に変換する', () => {
+    it('converts \\\\ to \\', () => {
       expect(renderTemplate('path\\\\file', {})).toBe('path\\file')
     })
 
-    it('エスケープされた変数は置換しない', () => {
-      expect(renderTemplate('\\{date\\} と {date}', { date: '4月26日(日)' })).toBe(
-        '{date} と 4月26日(日)',
+    it('does not substitute escaped variables', () => {
+      expect(renderTemplate('\\{date\\} and {date}', { date: 'Apr 26 (Sun)' })).toBe(
+        '{date} and Apr 26 (Sun)',
       )
     })
   })
 
-  describe('サンプルテンプレート', () => {
-    it('出勤時テンプレートを正しく置換する', () => {
+  describe('sample templates', () => {
+    it('renders the attendance template correctly', () => {
       expect(
         renderTemplate('明日 {date} は {time} からです', { date: '4月26日(日)', time: '9:00' }),
       ).toBe('明日 4月26日(日) は 9:00 からです')
     })
 
-    it('休みテンプレートを正しく置換する', () => {
+    it('renders the day-off template correctly', () => {
       expect(renderTemplate('明日 {date} はお休みです', { date: '4月26日(日)' })).toBe(
         '明日 4月26日(日) はお休みです',
       )
     })
   })
 
-  describe('エッジケース', () => {
-    it('空文字テンプレートはそのまま返す', () => {
+  describe('edge cases', () => {
+    it('returns an empty template as-is', () => {
       expect(renderTemplate('', {})).toBe('')
     })
 
-    it('変数のない文字列はそのまま返す', () => {
-      expect(renderTemplate('変数なしのテキスト', {})).toBe('変数なしのテキスト')
+    it('returns a string with no variables as-is', () => {
+      expect(renderTemplate('plain text with no variables', {})).toBe(
+        'plain text with no variables',
+      )
     })
 
-    it('テンプレート本文中の改行はそのまま出力する', () => {
-      expect(renderTemplate('1行目\n2行目 {date}', { date: '4月26日(日)' })).toBe(
-        '1行目\n2行目 4月26日(日)',
+    it('passes line breaks in the template body through to the output', () => {
+      expect(renderTemplate('line 1\nline 2 {date}', { date: 'Apr 26 (Sun)' })).toBe(
+        'line 1\nline 2 Apr 26 (Sun)',
       )
     })
   })

--- a/lib/validations/employee.test.ts
+++ b/lib/validations/employee.test.ts
@@ -2,42 +2,42 @@ import { describe, expect, it } from 'vitest'
 import { validatePhone } from './employee'
 
 describe('validatePhone', () => {
-  describe('有効な番号', () => {
-    it('BC州の番号を受け入れる', () => {
+  describe('valid numbers', () => {
+    it('accepts a BC number', () => {
       expect(validatePhone('+16042345678')).toBeNull()
     })
 
-    it('オンタリオ州の番号を受け入れる', () => {
+    it('accepts an Ontario number', () => {
       expect(validatePhone('+14162345678')).toBeNull()
     })
 
-    it('0・1始まり市外局番を拒否する', () => {
+    it('rejects area codes starting with 0 or 1', () => {
       expect(validatePhone('+11234567890')).not.toBeNull()
     })
   })
 
-  describe('無効な番号', () => {
-    it('+1 なしは拒否する', () => {
+  describe('invalid numbers', () => {
+    it('rejects a number without +1', () => {
       expect(validatePhone('6041234567')).not.toBeNull()
     })
 
-    it('桁数が足りない番号を拒否する', () => {
+    it('rejects a number with too few digits', () => {
       expect(validatePhone('+1604123456')).not.toBeNull()
     })
 
-    it('桁数が多い番号を拒否する', () => {
+    it('rejects a number with too many digits', () => {
       expect(validatePhone('+160412345678')).not.toBeNull()
     })
 
-    it('空文字を拒否する', () => {
+    it('rejects an empty string', () => {
       expect(validatePhone('')).not.toBeNull()
     })
 
-    it('日本の番号形式を拒否する', () => {
+    it('rejects a Japanese-format number', () => {
       expect(validatePhone('+819012345678')).not.toBeNull()
     })
 
-    it('スペースが残っている番号を拒否する（除去前の値）', () => {
+    it('rejects a number with remaining spaces (pre-stripped value)', () => {
       expect(validatePhone('+1 604 234 5678')).not.toBeNull()
     })
   })

--- a/lib/validations/employee.ts
+++ b/lib/validations/employee.ts
@@ -3,7 +3,7 @@ const CANADIAN_PHONE_RE = /^\+1[2-9]\d{2}[2-9]\d{6}$/
 
 export function validatePhone(phone: string): string | null {
   if (!CANADIAN_PHONE_RE.test(phone)) {
-    return 'E.164形式で入力してください（例: +16041234567）'
+    return 'Enter the number in E.164 format (e.g. +16041234567)'
   }
   return null
 }


### PR DESCRIPTION
## Summary

Follow-up to the documentation translation PR. Translates the remaining user-facing Japanese strings — error messages returned by Server Actions and API routes — plus the test suite descriptions. This completes the repository-wide English localization.

## Changes

- Translated 9 error message strings:
  - `lib/validations/employee.ts` — phone validation message
  - `app/(dashboard)/employees/actions.ts`, `app/(dashboard)/shifts/actions.ts` — action error returns
  - `app/api/shifts/messages/route.ts`, `app/api/shifts/messages/sent/route.ts` — API error responses (status codes and JSON shape unchanged, so the iOS Shortcut is unaffected)
- Translated test descriptions and fixtures in `lib/validations/employee.test.ts` and `lib/utils/render-template.test.ts`

## Deliberately left as-is

- The "sample templates" test block keeps the Japanese fixture strings — those tests verify that the actual production seed templates render correctly, so the fixtures must match the seed data
- The iOS Shortcut name in `shift-grid.tsx` (same reason as the previous PR)

## How to Verify

1. `npx vitest run` — all 21 tests pass
2. Trigger a validation error on the employee form (e.g. invalid phone number) — the message now displays in English
